### PR TITLE
removed deprecated strstream

### DIFF
--- a/include/VF3SubState.hpp
+++ b/include/VF3SubState.hpp
@@ -32,9 +32,8 @@ namespace vflib
 		class VF3SubState : public State
 	{
 	private:
-
-		bool induced;
-		//Comparison functors for nodes and edges
+		
+    //Comparison functors for nodes and edges
 		NodeComparisonFunctor nf;
 		EdgeComparisonFunctor ef;
 


### PR DESCRIPTION
[strstream](https://en.cppreference.com/w/cpp/io/strstream) is deprecated since C++98. Modified it to istrstream to istringstream.
Also added std::endl to the output from main.cpp.