### PR TITLE
Add support for integer edge labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ all: vf3 vf3l
 vf3:
 	$(CC) $(CFLAGS) $(CPPFLAGS) -o bin/$@ main.cpp -DVF3
 
+vf3.so:
+	$(CC) $(CFLAGS) $(CPPFLAGS) -fPIC -shared -o bin/$@ main.cpp -DVF3
+
 vf3l:
 	$(CC) $(CFLAGS) $(CPPFLAGS) -o bin/$@ main.cpp -DVF3L
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following additional parameters can be added to the commandline:
 * -s Print all the solutions (not only the number of solutions found) (Default: false)
 * -f Loader file format. Using this parameter you can specify the format of the graphs to be loaded: (Default: vf)
   * vf: stanard VF file format. Commonl used by the MIVIA Graph datasets
+  * vfe: Same as VF but also supports edge labels
   * edge: Edge file format commonly used on VLDB datasets such as (Patents, WebGoogle, etc...)
 
 ### VF3P additional parameters

--- a/include/ARGraph.hpp
+++ b/include/ARGraph.hpp
@@ -3,7 +3,8 @@
  * @author P. Foggia (pfoggia\@unisa.it)
  * @author V.Carletti (vcarletti\@unisa.it)
  * @date   December, 2014
- * @brief  Definition of a class representing an Attributed Relational Graph (ARG).
+ * @brief  Definition of a class representing an Attributed Relational Graph
+ * (ARG).
  */
 
 #ifndef ARGRAPH_H
@@ -12,659 +13,610 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <limits>
-#include <vector>
 
 #include <Error.hpp>
-
-namespace vflib
-{
-
-	typedef uint32_t nodeID_t; /**<Type for the id of the nodes in the graph */
-	const nodeID_t NULL_NODE = (std::numeric_limits<uint32_t>::max)();	/**<Null node value */
-
-	/**
-	 * @class Empty
-	 * @brief Class for the default empty attribute.
-	 * This class should be used for void attributes of nodes or edges.
-	 */
-	class Empty {
-		public:
-			friend std::istream& operator>>(std::istream& is, Empty& e)
-			{
-				return is;
-			}
-
-			bool operator== (Empty &e2) {
-				return true;
-			}
-
-			friend inline bool operator< (const Empty & s1, const Empty & s2)
-			{
-				return  false;
-			}
-
-	};
-
-	/**
-	 * @class EqualityComparator
-	 * @brief Default Functors for Node/Edge Attributes Equality Test.
-	 */
-	template<typename T1, typename T2>
-	class EqualityComparator
-	{
-	public:
-		bool operator()(T1& a, T2& b)
-		{
-			return a == b;
-		}
-	};
-
-	/**
-	* @class ARGLoader
-	* @brief Abstract class ARGLoader. Allows to construct an ARGraph.
-	* @note  The abstract class, ARGLoader, is defined to allow the
-	* 	use of different file formats for loading the graphs.\n
-	* 	The loader is queried by the ARGraph to acquire the information
-	* 	needed for building the graph.\n
-	* 	A simple ARGLoader based on iostream.h is provided in argloader.hpp;
-	* @see argloader.hpp
-	*/
-	template<typename Node, typename Edge>
-	class ARGLoader
-	{
-	public:
-		virtual ~ARGLoader() {}
-
-		/**
-		* @brief Counts the number of loaded nodes
-		* @returns Number of loaded nodes.
-		*/
-		virtual uint32_t NodeCount() const = 0;
-		/**
-		* @brief Returns the attribute of a given node.
-		* @param [in] node Node id.
-		* @returns Attribute of the node.
-		*/
-		virtual Node GetNodeAttr(nodeID_t node) = 0;
-		/**
-		* @brief Counts the number of edges out going from a given node.
-		* @param [in] node Node id.
-		* @returns Number of out going edges.
-		*/
-		virtual uint32_t OutEdgeCount(nodeID_t node) const = 0;
-		/**
-		* @brief Returns the End node of the i-th edge out going from a given node.
-		* @param [in] node Node id.
-		* @param [in] i Index of the edge.
-		* @param [out] pattr Attribute of the edge.
-		* @returns End node id.
-		*/
-		virtual nodeID_t GetOutEdge(nodeID_t node, uint32_t i, Edge *pattr) = 0;
-	};
-
-	/**
-	* @class ARGraph
-	* @brief This is the real representation of an ARG.
-	* @note The graphs, once created, are immutable, in the sense that
-	* graph-editing operations are not provided.\n
-	* This allows the use of an internal representation particularly
-	* suited for efficient graph matching, which is the primary target
-	* of this program.
-	*
-	* Edges and edge attributes (pointers) are stored into sorted
-	* vectors associated to each node, and are looked for
-	* using binary search.
-	*
-	* Nodes are identified using the type node_id, which is currently
-	* unsigned short; the special value NULL_NODE is used as null
-	* value for this type.
-	*
-	* Bound checks are performed using the assert macro. They can be
-	* disabled by ensuring the macro NDEBUG is defined during
-	* compilation.
-	*
-	* Differently from the previous versions  of this library
-	* (before version 2.0), there is no more an adjacency matrix to
-	* check for the existence of a node.
-	* @see argloader.hpp
-	* @see argedit.hpp
-	*/
-	template <typename Node, typename Edge>
-	class ARGraph
-	{
-	public:
-
-		typedef void *param_type;			/**<Type for the generic parameter of the visitor */
-		typedef void(*edge_visitor)(ARGraph *g,
-			nodeID_t n1, nodeID_t n2, Edge *attr,
-			param_type param);					/**<Type for the visitor of edges in the graph */
-
-	private:
-		typedef std::vector<nodeID_t> NodeVec;
-		typedef std::vector<Edge> EdgeAttrVector;
-		typedef std::vector<Node> NodeAttrVector;
-
-		uint32_t n;                               /**<number of nodes  */
-		uint32_t n_attr_count;					  /**<number of different node attributes */
-		uint32_t e_attr_count;					  /**<number of different edge attributes */
-		uint32_t e_count;						  /**<number of edges */
-		uint32_t e_out_count;					  /**<total number of out edges */
-		uint32_t e_in_count;					  /**<total number of in edges */
-		uint32_t node_label_count;				  /**<number of nodes labels */
-		uint32_t max_deg_in;                      /**<max in degree over all the nodes*/
-		uint32_t max_deg_out;                     /**<max out degree over all the nodes */
-		uint32_t max_degree;                      /**<max degree over all the nodes */
-		NodeAttrVector attr;                 /**<node attributes  */
-		std::vector<EdgeAttrVector> in_attr;      /**<Edge attributes for 'in' edges */
-		std::vector<EdgeAttrVector> out_attr;     /**<Edge attributes for 'out' edges */
-		std::vector<NodeVec> in;                  /**<nodes connected by 'in' edges to each n*/
-		std::vector<NodeVec> out;                 /**<nodes connected by 'out' edges to each node */
-
-		bool GetNodeIndex(nodeID_t n1, nodeID_t n2, nodeID_t &index) const;
-
-	public:
-		ARGraph(ARGLoader<Node, Edge> *loader);
-
-		uint32_t NodeCount() const;
-		uint32_t EdgeCount() const;
-		uint32_t InEdgeCount() const;
-		uint32_t OutEdgeCount() const;
-
-		Node& GetNodeAttr(nodeID_t i);
-		void SetNodeAttr(nodeID_t i, Node &attr);
-
-		bool HasEdge(nodeID_t n1, nodeID_t n2) const;
-		bool HasEdge(nodeID_t n1, nodeID_t n2, Edge &pattr) const;
-		Edge& GetEdgeAttr(nodeID_t n1, nodeID_t n2);
-		void SetEdgeAttr(nodeID_t n1, nodeID_t n2, Edge &attr);
-
-		uint32_t InEdgeCount(nodeID_t node) const;
-		uint32_t OutEdgeCount(nodeID_t node) const;
-		uint32_t EdgeCount(nodeID_t node) const;
-		nodeID_t GetInEdge(nodeID_t node, uint32_t i) const;
-		nodeID_t GetInEdge(nodeID_t node, uint32_t i, Edge& pattr) const;
-		nodeID_t GetOutEdge(nodeID_t node, uint32_t i) const;
-		nodeID_t GetOutEdge(nodeID_t node, uint32_t i, Edge& pattr) const;
-		nodeID_t* GetOutEdgeSet(nodeID_t node);
-		nodeID_t* GetInEdgeSet(nodeID_t node);
-
-		/**
-		* @brief Maximum incoming degree in the graph
-		* @returns Maximum in degree
-		*/
-		uint32_t InMaxDegree() const { return max_deg_in; }
-		/**
-		* @brief Maximum out going degree in the graph
-		* @returns Maximum out degree
-		*/
-		uint32_t OutMaxDegree() const { return max_deg_out; }
-		/**
-		* @brief Maximum degree in the graph
-		* @returns Maximum degree
-		*/
-		uint32_t MaxDegree() const { return max_degree; }
-
-		/**
-		* @brief Number of different node attibute in the graph
-		* @returns Number of different node attibute
-		*/
-		uint32_t NodeAttrCount() const { return n_attr_count; }
-
-		/**
-		* @brief Number of different edge attibute in the graph
-		* @returns Number of different edge attibute
-		*/
-		uint32_t EdgeAttrCount() const { return e_attr_count; }
-
-		void VisitInEdges(nodeID_t node, edge_visitor vis, param_type param);
-		void VisitOutEdges(nodeID_t node, edge_visitor vis, param_type param);
-		void VisitEdges(nodeID_t node, edge_visitor vis, param_type param);
-	};
-
-	/**
-	* @brief Returns the number of nodes in the graph
-	* @returns Number of nodes
-	*/
-	template <typename Node, typename Edge>
-	inline uint32_t ARGraph<Node, Edge>::NodeCount() const
-	{
-		return n;
-	}
-
-	/**
-	* @brief Returns the number of edge in the graph
-	* @returns Number of edge
-	*/
-	template <typename Node, typename Edge>
-	inline uint32_t ARGraph<Node, Edge>::EdgeCount() const
-	{
-		return e_count;
-	}
-
-		/**
-	* @brief Returns the number of in edges in the graph
-	* @returns Number of in edges
-	*/
-	template <typename Node, typename Edge>
-	inline uint32_t ARGraph<Node, Edge>::InEdgeCount() const
-	{
-		return e_in_count;
-	}
-
-		/**
-	* @brief Returns the number of out edges in the graph
-	* @returns Number of out edges
-	*/
-	template <typename Node, typename Edge>
-	inline uint32_t ARGraph<Node, Edge>::OutEdgeCount() const
-	{
-		return e_out_count;
-	}
-
-	/**
-	* @brief Return the attribute of a given node.
-	* @param [in] id Node id.
-	* @returns Attribute of the node.
-	*/
-	template <typename Node, typename Edge>
-	inline Node& ARGraph<Node, Edge>::GetNodeAttr(nodeID_t id)
-	{
-		assert(id < n);
-		return attr[id];
-	}
-
-	/**
-	* @brief Check the presence of an edge.
-	* @param [in] n1 Start node id.
-	* @param [in] n2 End node id.
-	* @retval TRUE If the edge exists.
-	* @retval FALSE If the edge doesn't exist.
-	*/
-	template <typename Node, typename Edge>
-	inline bool ARGraph<Node, Edge>::HasEdge(nodeID_t n1, nodeID_t n2) const
-	{
-		nodeID_t index;
-		return GetNodeIndex(n1, n2, index);
-	}
-
-	/**
-	* @brief Gets the index of node n2 in the neighboors set of n1.
-	* @param [in] n1 First node id.
-	* @param [in] n2 Second node id.
-	* @param [out] index Index of the node n2 in the neighboors set of n1.
-	* @retval TRUE If the the nodes n2 is a neighboor of n1.
-	* @retval FALSE If the the nodes n2 isn't a neighboor of n1.
-	*/
-	template <typename Node, typename Edge>
-	inline bool ARGraph<Node, Edge>::GetNodeIndex(nodeID_t n1, nodeID_t n2, nodeID_t &index) const
-	{
-		unsigned long a, b, c;
-		//NodeVec id = out[n1];
-
-		assert(n1 < n);
-		assert(n2 < n);
-
-		a = 0;
-		b = out[n1].size();
-		while (a < b)
-		{
-			c = (unsigned)(a + b) >> 1;
-			if (out[n1][c] < n2)
-				a = c + 1;
-			else if (out[n1][c] > n2)
-				b = c;
-			else
-			{
-				index = c;
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	* @brief Gets the attribute of an edge.
-	* @note The method assumes that the edge exists.
-	* @param [in] n1 Start node id.
-	* @param [in] n2 End node id.
-	* @returns the attribute of the edge.
-	*/
-	template <typename Node, typename Edge>
-	inline Edge& ARGraph<Node, Edge>::GetEdgeAttr(nodeID_t n1, nodeID_t n2)
-	{
-		nodeID_t index;
-		assert(GetNodeIndex(n1, n2, index) == true);
-		return out_attr[n1][index];
-	}
-
-	/**
-	* @brief Returns the number of edges going into a node.
-	* @param [in] node Node id.
-	* @returns Number of edges going into a node.
-	*/
-	template <typename Node, typename Edge>
-	inline uint32_t ARGraph<Node, Edge>::InEdgeCount(nodeID_t node) const
-	{
-		assert(node < n);
-		return (int)in[node].size();
-	}
-
-
-	/**
-	* @brief Returns the number of edges departing from a node.
-	* @param [in] node Node id.
-	* @returns Number of edges departing from a node.
-	*/
-	template <typename Node, typename Edge>
-	inline uint32_t ARGraph<Node, Edge>::OutEdgeCount(nodeID_t node) const
-	{
-		assert(node < n);
-		return (int)out[node].size();
-	}
-
-	/**
-	* @brief Returns the full valence (in and out) of a node.
-	* @param [in] node Node id.
-	* @returns Number of edges of a node.
-	*/
-	template <typename Node, typename Edge>
-	inline uint32_t ARGraph<Node, Edge>::EdgeCount(nodeID_t node) const
-	{
-		assert(node < n);
-		return in[node].size() + out[node].size();
-	}
-
-	/**
-	* @brief Gets the other end of an edge entering a node.
-	* @param [in] node Node id.
-	* @param [in] i Index of the neighboor of the node.
-	* @returns Other end of the edge.
-	*/
-	template <typename Node, typename Edge>
-	inline nodeID_t ARGraph<Node, Edge>::GetInEdge(nodeID_t node, uint32_t i) const
-	{
-		assert(node < n);
-		assert(i < in[node].size());
-		if (node == 2 && i == 0)
-			return in[node][i];
-		return in[node][i];
-	}
-
-	/**
-	* @brief Gets the other end of an edge entering a node and its attribute.
-	* @param [in] node Node id.
-	* @param [in] i Index of the neighboor of the node.
-	* @param [out] pattr Attribute of the edge.
-	* @returns Other end of the edge.
-	*/
-	template <typename Node, typename Edge>
-	inline nodeID_t ARGraph<Node, Edge>::GetInEdge(nodeID_t node, uint32_t i,
-		Edge& pattr) const
-	{
-		assert(node < n);
-		assert(i < in[node].size());
-		pattr = in_attr[node][i];
-		return in[node][i];
-	}
-
-	/**
-	* @brief Gets the other end of an edge leaving a node.
-	* @param [in] node Node id.
-	* @param [in] i Index of the neighboor of the node.
-	* @returns Other end of the edge.
-	*/
-	template <typename Node, typename Edge>
-	inline nodeID_t ARGraph<Node, Edge>::GetOutEdge(nodeID_t node, uint32_t i) const
-	{
-		assert(node < n);
-		assert(i < out[node].size());
-		return out[node][i];
-	}
-
-	/**
-	* @brief Gets the other end of an edge leaving a node and its attribute.
-	* @param [in] node Node id.
-	* @param [in] i Index of the neighboor of the node.
-	* @param [out] pattr Attribute of the edge.
-	* @returns Other end of the edge.
-	*/
-	template <typename Node, typename Edge>
-	inline nodeID_t ARGraph<Node, Edge>::GetOutEdge(nodeID_t node, uint32_t i,
-		Edge& pattr) const
-	{
-		assert(node < n);
-		assert(i < out[node].size());
-		pattr = out_attr[node][i];
-		return out[node][i];
-	}
-
-	/**
-	* @brief Change the attribute of a node.
-	* @param [in] i Node id.
-	* @param [int] new_attr Attribute of the node.
-	*/
-	template <typename Node, typename Edge>
-	void ARGraph<Node, Edge>::SetNodeAttr(nodeID_t i, Node &new_attr)
-	{
-		assert(i < n);
-		attr[i] = new_attr;
-	}
-
-	/**
-	 * @brief Gets the set of out edges
-	 * @param [in] node Node id.
-	 * @returns Set of out edges
-	 */
-	template <typename Node, typename Edge>
-	inline nodeID_t* ARGraph<Node, Edge>::GetOutEdgeSet(nodeID_t node)
-	{
-		return out[node].data();
-	}
-
-	/**
-	 * @brief Gets the set of in edges
-	 * @param [in] node Node id.
-	 * @returns Set of in edges
-	 */
-	template <typename Node, typename Edge>
-	inline nodeID_t* ARGraph<Node, Edge>::GetInEdgeSet(nodeID_t node)
-	{
-		return in[node].data();
-	}
-
-	/*-------------------------------------------------------------------
-	 * Checks the existence of an edge, and returns its attribute
-	 * using the parameter pattr.
-	 * Note: uses binary search.
-	 * Implem. note: Uses the out/out_attr vectors; this fact is
-	 *               exploited in the constructor to generate the
-	 *               in_attr vector
-	 ------------------------------------------------------------------*/
-	 /**
-	 * @brief Checks the existence of an edge, and returns its attribute.
-	 * @note The method uses binary search. \n
-	 *	Uses the out/out_attr vectors; this fact is exploited in the
-	 *	constructor to generate the in_attr vector.
-	 * @param [in] n1 Start node id.
-	 * @param [in] n2 End node id.
-	 * @param [out] pattr Attribute of the edge.
-	 * @retval TRUE If the edge exists.
-	 * @retval FALSE If the edge doesn't exist.
-	 */
-	template <typename Node, typename Edge>
-	bool ARGraph<Node, Edge>::HasEdge(nodeID_t n1, nodeID_t n2, Edge &pattr) const
-	{
-		nodeID_t index;
-		if (GetNodeIndex(n1, n2, index)) {
-			pattr = out_attr[n1][index];
-			return true;
-		}
-		return false;
-	}
-
-	/**
-	* @brief Change the attribute of an edge. It is an error if the edge does not exist.
-	* @note The method uses binary search.
-	* @param [in] n1 Start node id.
-	* @param [in] n2 End node id.
-	* @param [in] pattr Attribute of the edge.
-	*/
-	template <typename Node, typename Edge>
-	void  ARGraph<Node, Edge>::SetEdgeAttr(nodeID_t n1, nodeID_t n2, Edge& new_attr)
-	{
-		uint32_t c;
-		assert(n1 < n);
-		assert(n2 < n);
-
-		if (GetNodeIndex(n1, n2, c))
-			out_attr[n1][c] = new_attr;
-
-		if (GetNodeIndex(n2, n1, c))
-			in_attr[n2][c] = new_attr;
-	}
-
-	/**
-	* @brief Applies the visitor to all the in edges of the node.
-	* @param [in] node Node id.
-	* @param [in] vis Edge Visitor.
-	* @param [in] param Generic param for the visitor.
-	*/
-	template <typename Node, typename Edge>
-	void ARGraph<Node, Edge>::VisitInEdges(nodeID_t node, edge_visitor vis,
-		param_type param)
-	{
-		assert(node < n);
-		size_t i;
-		for (i = 0; i < in[node].size(); i++)
-			vis(this, in[node][i], node, in_attr[node][i], param);
-	}
-
-	/**
-	* @brief Applies the visitor to all the out edges of the node.
-	* @param [in] node Node id.
-	* @param [in] vis Edge Visitor.
-	* @param [in] param Generic param for the visitor.
-	*/
-	template <typename Node, typename Edge>
-	void ARGraph<Node, Edge>::VisitOutEdges(nodeID_t node, edge_visitor vis,
-		param_type param)
-	{
-		assert(node < n);
-		size_t i;
-		for (i = 0; i < out[node].size(); i++)
-			vis(this, node, out[node][i], out_attr[node][i], param);
-	}
-
-	/**
-	* @brief Applies the visitor to all the edges of the node.
-	* @param [in] node Node id.
-	* @param [in] vis Edge Visitor.
-	* @param [in] param Generic param for the visitor.
-	*/
-	template <typename Node, typename Edge>
-	void ARGraph<Node, Edge>::VisitEdges(nodeID_t node, edge_visitor vis, param_type param)
-	{
-		VisitInEdges(node, vis, param);
-		VisitOutEdges(node, vis, param);
-	}
-
-	/**
-	* @brief Constructs the graph form a loader.
-	* @param loader ARGLoader
-	*/
-	template <typename Node, typename Edge>
-	ARGraph<Node, Edge>::ARGraph(ARGLoader<Node, Edge> *loader)
-	{
-		n = loader->NodeCount();
-                attr.resize(n);
-                in.resize(n);
-                in_attr.resize(n);
-                out.resize(n);
-                out_attr.resize(n);
-
-		e_count = 0;
-		e_out_count = 0;
-		e_in_count = 0;
-		n_attr_count = 0;
-		e_attr_count = 0;
-		std::map<Node, bool> attributemap;
-		std::map<Edge, bool> e_attributemap;
-
-		max_deg_in = max_deg_out = max_degree = 0;
-
-                std::vector< std::map< nodeID_t, Edge> > revmap;
-                typename std::map< nodeID_t, Edge>::iterator rvit;
-                revmap.resize(n);
-
-		uint32_t i, j;
-		for (i = 0; i < n; i++)
-		{
-			Node attribute = loader->GetNodeAttr(i);
-			attr[i]=(attribute);
-
-			if(!attributemap.count(attribute))
-			{ 
-				attributemap[attribute]=true;
-				n_attr_count++;
-			}
-		}
-
-		for (i = 0; i < n; i++)
-		{
-			uint32_t k = loader->OutEdgeCount(i);
-			e_out_count += k;
-
-			if (k > max_deg_out)
-				max_deg_out = k;
-                        out[i].resize(k);
-                        out_attr[i].resize(k);
-
-			for (j = 0; j < k; j++)
-			{
-                                nodeID_t n2 = loader->GetOutEdge(i, j,
-                                                     &out_attr[i][j]);
-				out[i][j]=n2;
-                                revmap[n2][i]=out_attr[i][j];
-			}
-		}
-
-		for (i = 0; i < n; i++)
-		{
-			uint32_t k = revmap[i].size();
-			e_in_count += k;
-
-			if (k > max_deg_in)
-				max_deg_in = k;
-                        
-                        in[i].resize(k);
-                        in_attr[i].resize(k);
-
-			for (j = 0, rvit=revmap[i].begin(); j < k; j++, rvit++)
-			{ in[i][j] = rvit->first;
-                          Edge edge_attr=rvit->second;
-                          in_attr[i][j]=edge_attr;
-			  if(!e_attributemap.count(edge_attr)) { 
-				e_attributemap[edge_attr]=true;
-				e_attr_count++;
-			  }
-			}
-
-		}
-
-		for (i = 0; i < n; i++) {
-			uint32_t count = in[i].size() + out[i].size();
-			e_count += count;
-			if (count > max_degree) {
-				max_degree = count;
-			}
-		}
-
-	}
-
+#include <limits>
+#include <map>
+#include <vector>
+
+namespace vflib {
+
+typedef uint32_t nodeID_t; /**<Type for the id of the nodes in the graph */
+const nodeID_t NULL_NODE =
+    (std::numeric_limits<uint32_t>::max)(); /**<Null node value */
+
+/**
+ * @class Empty
+ * @brief Class for the default empty attribute.
+ * This class should be used for void attributes of nodes or edges.
+ */
+class Empty {
+ public:
+  friend std::istream& operator>>(std::istream& is, Empty& e) { return is; }
+
+  bool operator==(Empty& e2) { return true; }
+
+  friend inline bool operator<(const Empty& s1, const Empty& s2) {
+    return false;
+  }
+};
+
+/**
+ * @class EqualityComparator
+ * @brief Default Functors for Node/Edge Attributes Equality Test.
+ */
+template <typename T1, typename T2>
+class EqualityComparator {
+ public:
+  bool operator()(T1& a, T2& b) { return a == b; }
+};
+
+/**
+ * @class ARGLoader
+ * @brief Abstract class ARGLoader. Allows to construct an ARGraph.
+ * @note  The abstract class, ARGLoader, is defined to allow the
+ * 	use of different file formats for loading the graphs.\n
+ * 	The loader is queried by the ARGraph to acquire the information
+ * 	needed for building the graph.\n
+ * 	A simple ARGLoader based on iostream.h is provided in argloader.hpp;
+ * @see argloader.hpp
+ */
+template <typename Node, typename Edge>
+class ARGLoader {
+ public:
+  virtual ~ARGLoader() {}
+
+  /**
+   * @brief Counts the number of loaded nodes
+   * @returns Number of loaded nodes.
+   */
+  virtual uint32_t NodeCount() const = 0;
+  /**
+   * @brief Returns the attribute of a given node.
+   * @param [in] node Node id.
+   * @returns Attribute of the node.
+   */
+  virtual Node GetNodeAttr(nodeID_t node) = 0;
+  /**
+   * @brief Counts the number of edges out going from a given node.
+   * @param [in] node Node id.
+   * @returns Number of out going edges.
+   */
+  virtual uint32_t OutEdgeCount(nodeID_t node) const = 0;
+  /**
+   * @brief Returns the End node of the i-th edge out going from a given node.
+   * @param [in] node Node id.
+   * @param [in] i Index of the edge.
+   * @param [out] pattr Attribute of the edge.
+   * @returns End node id.
+   */
+  virtual nodeID_t GetOutEdge(nodeID_t node, uint32_t i, Edge* pattr) = 0;
+};
+
+/**
+ * @class ARGraph
+ * @brief This is the real representation of an ARG.
+ * @note The graphs, once created, are immutable, in the sense that
+ * graph-editing operations are not provided.\n
+ * This allows the use of an internal representation particularly
+ * suited for efficient graph matching, which is the primary target
+ * of this program.
+ *
+ * Edges and edge attributes (pointers) are stored into sorted
+ * vectors associated to each node, and are looked for
+ * using binary search.
+ *
+ * Nodes are identified using the type node_id, which is currently
+ * unsigned short; the special value NULL_NODE is used as null
+ * value for this type.
+ *
+ * Bound checks are performed using the assert macro. They can be
+ * disabled by ensuring the macro NDEBUG is defined during
+ * compilation.
+ *
+ * Differently from the previous versions  of this library
+ * (before version 2.0), there is no more an adjacency matrix to
+ * check for the existence of a node.
+ * @see argloader.hpp
+ * @see argedit.hpp
+ */
+template <typename Node, typename Edge>
+class ARGraph {
+ public:
+  typedef void* param_type; /**<Type for the generic parameter of the visitor */
+  typedef void (*edge_visitor)(
+      ARGraph* g, nodeID_t n1, nodeID_t n2, Edge* attr,
+      param_type param); /**<Type for the visitor of edges in the graph */
+
+ private:
+  typedef std::vector<nodeID_t> NodeVec;
+  typedef std::vector<Edge> EdgeAttrVector;
+  typedef std::vector<Node> NodeAttrVector;
+
+  uint32_t n;                /**<number of nodes  */
+  uint32_t n_attr_count;     /**<number of different node attributes */
+  uint32_t e_attr_count;     /**<number of different edge attributes */
+  uint32_t e_count;          /**<number of edges */
+  uint32_t e_out_count;      /**<total number of out edges */
+  uint32_t e_in_count;       /**<total number of in edges */
+  uint32_t node_label_count; /**<number of nodes labels */
+  uint32_t max_deg_in;       /**<max in degree over all the nodes*/
+  uint32_t max_deg_out;      /**<max out degree over all the nodes */
+  uint32_t max_degree;       /**<max degree over all the nodes */
+  NodeAttrVector attr;       /**<node attributes  */
+  std::vector<EdgeAttrVector> in_attr;  /**<Edge attributes for 'in' edges */
+  std::vector<EdgeAttrVector> out_attr; /**<Edge attributes for 'out' edges */
+  std::vector<NodeVec> in;  /**<nodes connected by 'in' edges to each n*/
+  std::vector<NodeVec> out; /**<nodes connected by 'out' edges to each node */
+
+  bool GetNodeIndex(nodeID_t n1, nodeID_t n2, nodeID_t& index) const;
+
+ public:
+  ARGraph(ARGLoader<Node, Edge>* loader);
+
+  uint32_t NodeCount() const;
+  uint32_t EdgeCount() const;
+  uint32_t InEdgeCount() const;
+  uint32_t OutEdgeCount() const;
+
+  Node& GetNodeAttr(nodeID_t i);
+  void SetNodeAttr(nodeID_t i, Node& attr);
+
+  bool HasEdge(nodeID_t n1, nodeID_t n2) const;
+  bool HasEdge(nodeID_t n1, nodeID_t n2, Edge& pattr) const;
+  Edge& GetEdgeAttr(nodeID_t n1, nodeID_t n2);
+  void SetEdgeAttr(nodeID_t n1, nodeID_t n2, Edge& attr);
+
+  uint32_t InEdgeCount(nodeID_t node) const;
+  uint32_t OutEdgeCount(nodeID_t node) const;
+  uint32_t EdgeCount(nodeID_t node) const;
+  nodeID_t GetInEdge(nodeID_t node, uint32_t i) const;
+  nodeID_t GetInEdge(nodeID_t node, uint32_t i, Edge& pattr) const;
+  nodeID_t GetOutEdge(nodeID_t node, uint32_t i) const;
+  nodeID_t GetOutEdge(nodeID_t node, uint32_t i, Edge& pattr) const;
+  nodeID_t* GetOutEdgeSet(nodeID_t node);
+  nodeID_t* GetInEdgeSet(nodeID_t node);
+
+  /**
+   * @brief Maximum incoming degree in the graph
+   * @returns Maximum in degree
+   */
+  uint32_t InMaxDegree() const { return max_deg_in; }
+  /**
+   * @brief Maximum out going degree in the graph
+   * @returns Maximum out degree
+   */
+  uint32_t OutMaxDegree() const { return max_deg_out; }
+  /**
+   * @brief Maximum degree in the graph
+   * @returns Maximum degree
+   */
+  uint32_t MaxDegree() const { return max_degree; }
+
+  /**
+   * @brief Number of different node attibute in the graph
+   * @returns Number of different node attibute
+   */
+  uint32_t NodeAttrCount() const { return n_attr_count; }
+
+  /**
+   * @brief Number of different edge attibute in the graph
+   * @returns Number of different edge attibute
+   */
+  uint32_t EdgeAttrCount() const { return e_attr_count; }
+
+  void VisitInEdges(nodeID_t node, edge_visitor vis, param_type param);
+  void VisitOutEdges(nodeID_t node, edge_visitor vis, param_type param);
+  void VisitEdges(nodeID_t node, edge_visitor vis, param_type param);
+};
+
+/**
+ * @brief Returns the number of nodes in the graph
+ * @returns Number of nodes
+ */
+template <typename Node, typename Edge>
+inline uint32_t ARGraph<Node, Edge>::NodeCount() const {
+  return n;
 }
+
+/**
+ * @brief Returns the number of edge in the graph
+ * @returns Number of edge
+ */
+template <typename Node, typename Edge>
+inline uint32_t ARGraph<Node, Edge>::EdgeCount() const {
+  return e_count;
+}
+
+/**
+ * @brief Returns the number of in edges in the graph
+ * @returns Number of in edges
+ */
+template <typename Node, typename Edge>
+inline uint32_t ARGraph<Node, Edge>::InEdgeCount() const {
+  return e_in_count;
+}
+
+/**
+ * @brief Returns the number of out edges in the graph
+ * @returns Number of out edges
+ */
+template <typename Node, typename Edge>
+inline uint32_t ARGraph<Node, Edge>::OutEdgeCount() const {
+  return e_out_count;
+}
+
+/**
+ * @brief Return the attribute of a given node.
+ * @param [in] id Node id.
+ * @returns Attribute of the node.
+ */
+template <typename Node, typename Edge>
+inline Node& ARGraph<Node, Edge>::GetNodeAttr(nodeID_t id) {
+  assert(id < n);
+  return attr[id];
+}
+
+/**
+ * @brief Check the presence of an edge.
+ * @param [in] n1 Start node id.
+ * @param [in] n2 End node id.
+ * @retval TRUE If the edge exists.
+ * @retval FALSE If the edge doesn't exist.
+ */
+template <typename Node, typename Edge>
+inline bool ARGraph<Node, Edge>::HasEdge(nodeID_t n1, nodeID_t n2) const {
+  nodeID_t index;
+  return GetNodeIndex(n1, n2, index);
+}
+
+/**
+ * @brief Gets the index of node n2 in the neighboors set of n1.
+ * @param [in] n1 First node id.
+ * @param [in] n2 Second node id.
+ * @param [out] index Index of the node n2 in the neighboors set of n1.
+ * @retval TRUE If the the nodes n2 is a neighboor of n1.
+ * @retval FALSE If the the nodes n2 isn't a neighboor of n1.
+ */
+template <typename Node, typename Edge>
+inline bool ARGraph<Node, Edge>::GetNodeIndex(nodeID_t n1, nodeID_t n2,
+                                              nodeID_t& index) const {
+  unsigned long a, b, c;
+  // NodeVec id = out[n1];
+
+  assert(n1 < n);
+  assert(n2 < n);
+
+  a = 0;
+  b = out[n1].size();
+  while (a < b) {
+    c = (unsigned)(a + b) >> 1;
+    if (out[n1][c] < n2)
+      a = c + 1;
+    else if (out[n1][c] > n2)
+      b = c;
+    else {
+      index = c;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * @brief Gets the attribute of an edge.
+ * @note The method assumes that the edge exists.
+ * @param [in] n1 Start node id.
+ * @param [in] n2 End node id.
+ * @returns the attribute of the edge.
+ */
+template <typename Node, typename Edge>
+inline Edge& ARGraph<Node, Edge>::GetEdgeAttr(nodeID_t n1, nodeID_t n2) {
+  nodeID_t index;
+  assert(GetNodeIndex(n1, n2, index) == true);
+  return out_attr[n1][index];
+}
+
+/**
+ * @brief Returns the number of edges going into a node.
+ * @param [in] node Node id.
+ * @returns Number of edges going into a node.
+ */
+template <typename Node, typename Edge>
+inline uint32_t ARGraph<Node, Edge>::InEdgeCount(nodeID_t node) const {
+  assert(node < n);
+  return (int)in[node].size();
+}
+
+/**
+ * @brief Returns the number of edges departing from a node.
+ * @param [in] node Node id.
+ * @returns Number of edges departing from a node.
+ */
+template <typename Node, typename Edge>
+inline uint32_t ARGraph<Node, Edge>::OutEdgeCount(nodeID_t node) const {
+  assert(node < n);
+  return (int)out[node].size();
+}
+
+/**
+ * @brief Returns the full valence (in and out) of a node.
+ * @param [in] node Node id.
+ * @returns Number of edges of a node.
+ */
+template <typename Node, typename Edge>
+inline uint32_t ARGraph<Node, Edge>::EdgeCount(nodeID_t node) const {
+  assert(node < n);
+  return in[node].size() + out[node].size();
+}
+
+/**
+ * @brief Gets the other end of an edge entering a node.
+ * @param [in] node Node id.
+ * @param [in] i Index of the neighboor of the node.
+ * @returns Other end of the edge.
+ */
+template <typename Node, typename Edge>
+inline nodeID_t ARGraph<Node, Edge>::GetInEdge(nodeID_t node,
+                                               uint32_t i) const {
+  assert(node < n);
+  assert(i < in[node].size());
+  if (node == 2 && i == 0) return in[node][i];
+  return in[node][i];
+}
+
+/**
+ * @brief Gets the other end of an edge entering a node and its attribute.
+ * @param [in] node Node id.
+ * @param [in] i Index of the neighboor of the node.
+ * @param [out] pattr Attribute of the edge.
+ * @returns Other end of the edge.
+ */
+template <typename Node, typename Edge>
+inline nodeID_t ARGraph<Node, Edge>::GetInEdge(nodeID_t node, uint32_t i,
+                                               Edge& pattr) const {
+  assert(node < n);
+  assert(i < in[node].size());
+  pattr = in_attr[node][i];
+  return in[node][i];
+}
+
+/**
+ * @brief Gets the other end of an edge leaving a node.
+ * @param [in] node Node id.
+ * @param [in] i Index of the neighboor of the node.
+ * @returns Other end of the edge.
+ */
+template <typename Node, typename Edge>
+inline nodeID_t ARGraph<Node, Edge>::GetOutEdge(nodeID_t node,
+                                                uint32_t i) const {
+  assert(node < n);
+  assert(i < out[node].size());
+  return out[node][i];
+}
+
+/**
+ * @brief Gets the other end of an edge leaving a node and its attribute.
+ * @param [in] node Node id.
+ * @param [in] i Index of the neighboor of the node.
+ * @param [out] pattr Attribute of the edge.
+ * @returns Other end of the edge.
+ */
+template <typename Node, typename Edge>
+inline nodeID_t ARGraph<Node, Edge>::GetOutEdge(nodeID_t node, uint32_t i,
+                                                Edge& pattr) const {
+  assert(node < n);
+  assert(i < out[node].size());
+  pattr = out_attr[node][i];
+  return out[node][i];
+}
+
+/**
+ * @brief Change the attribute of a node.
+ * @param [in] i Node id.
+ * @param [int] new_attr Attribute of the node.
+ */
+template <typename Node, typename Edge>
+void ARGraph<Node, Edge>::SetNodeAttr(nodeID_t i, Node& new_attr) {
+  assert(i < n);
+  attr[i] = new_attr;
+}
+
+/**
+ * @brief Gets the set of out edges
+ * @param [in] node Node id.
+ * @returns Set of out edges
+ */
+template <typename Node, typename Edge>
+inline nodeID_t* ARGraph<Node, Edge>::GetOutEdgeSet(nodeID_t node) {
+  return out[node].data();
+}
+
+/**
+ * @brief Gets the set of in edges
+ * @param [in] node Node id.
+ * @returns Set of in edges
+ */
+template <typename Node, typename Edge>
+inline nodeID_t* ARGraph<Node, Edge>::GetInEdgeSet(nodeID_t node) {
+  return in[node].data();
+}
+
+/*-------------------------------------------------------------------
+ * Checks the existence of an edge, and returns its attribute
+ * using the parameter pattr.
+ * Note: uses binary search.
+ * Implem. note: Uses the out/out_attr vectors; this fact is
+ *               exploited in the constructor to generate the
+ *               in_attr vector
+ ------------------------------------------------------------------*/
+/**
+ * @brief Checks the existence of an edge, and returns its attribute.
+ * @note The method uses binary search. \n
+ *	Uses the out/out_attr vectors; this fact is exploited in the
+ *	constructor to generate the in_attr vector.
+ * @param [in] n1 Start node id.
+ * @param [in] n2 End node id.
+ * @param [out] pattr Attribute of the edge.
+ * @retval TRUE If the edge exists.
+ * @retval FALSE If the edge doesn't exist.
+ */
+template <typename Node, typename Edge>
+bool ARGraph<Node, Edge>::HasEdge(nodeID_t n1, nodeID_t n2, Edge& pattr) const {
+  nodeID_t index;
+  if (GetNodeIndex(n1, n2, index)) {
+    pattr = out_attr[n1][index];
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Change the attribute of an edge. It is an error if the edge does not
+ * exist.
+ * @note The method uses binary search.
+ * @param [in] n1 Start node id.
+ * @param [in] n2 End node id.
+ * @param [in] pattr Attribute of the edge.
+ */
+template <typename Node, typename Edge>
+void ARGraph<Node, Edge>::SetEdgeAttr(nodeID_t n1, nodeID_t n2,
+                                      Edge& new_attr) {
+  uint32_t c;
+  assert(n1 < n);
+  assert(n2 < n);
+
+  if (GetNodeIndex(n1, n2, c)) out_attr[n1][c] = new_attr;
+
+  if (GetNodeIndex(n2, n1, c)) in_attr[n2][c] = new_attr;
+}
+
+/**
+ * @brief Applies the visitor to all the in edges of the node.
+ * @param [in] node Node id.
+ * @param [in] vis Edge Visitor.
+ * @param [in] param Generic param for the visitor.
+ */
+template <typename Node, typename Edge>
+void ARGraph<Node, Edge>::VisitInEdges(nodeID_t node, edge_visitor vis,
+                                       param_type param) {
+  assert(node < n);
+  size_t i;
+  for (i = 0; i < in[node].size(); i++)
+    vis(this, in[node][i], node, in_attr[node][i], param);
+}
+
+/**
+ * @brief Applies the visitor to all the out edges of the node.
+ * @param [in] node Node id.
+ * @param [in] vis Edge Visitor.
+ * @param [in] param Generic param for the visitor.
+ */
+template <typename Node, typename Edge>
+void ARGraph<Node, Edge>::VisitOutEdges(nodeID_t node, edge_visitor vis,
+                                        param_type param) {
+  assert(node < n);
+  size_t i;
+  for (i = 0; i < out[node].size(); i++)
+    vis(this, node, out[node][i], out_attr[node][i], param);
+}
+
+/**
+ * @brief Applies the visitor to all the edges of the node.
+ * @param [in] node Node id.
+ * @param [in] vis Edge Visitor.
+ * @param [in] param Generic param for the visitor.
+ */
+template <typename Node, typename Edge>
+void ARGraph<Node, Edge>::VisitEdges(nodeID_t node, edge_visitor vis,
+                                     param_type param) {
+  VisitInEdges(node, vis, param);
+  VisitOutEdges(node, vis, param);
+}
+
+/**
+ * @brief Constructs the graph form a loader.
+ * @param loader ARGLoader
+ */
+template <typename Node, typename Edge>
+ARGraph<Node, Edge>::ARGraph(ARGLoader<Node, Edge>* loader) {
+  n = loader->NodeCount();
+  attr.resize(n);
+  in.resize(n);
+  in_attr.resize(n);
+  out.resize(n);
+  out_attr.resize(n);
+
+  e_count = 0;
+  e_out_count = 0;
+  e_in_count = 0;
+  n_attr_count = 0;
+  e_attr_count = 0;
+  std::map<Node, bool> attributemap;
+  std::map<Edge, bool> e_attributemap;
+
+  max_deg_in = max_deg_out = max_degree = 0;
+
+  std::vector<std::map<nodeID_t, Edge> > revmap;
+  typename std::map<nodeID_t, Edge>::iterator rvit;
+  revmap.resize(n);
+
+  uint32_t i, j;
+  for (i = 0; i < n; i++) {
+    Node attribute = loader->GetNodeAttr(i);
+    attr[i] = (attribute);
+
+    if (!attributemap.count(attribute)) {
+      attributemap[attribute] = true;
+      n_attr_count++;
+    }
+  }
+
+  for (i = 0; i < n; i++) {
+    uint32_t k = loader->OutEdgeCount(i);
+    e_out_count += k;
+
+    if (k > max_deg_out) max_deg_out = k;
+    out[i].resize(k);
+    out_attr[i].resize(k);
+
+    for (j = 0; j < k; j++) {
+      nodeID_t n2 = loader->GetOutEdge(i, j, &out_attr[i][j]);
+      out[i][j] = n2;
+      revmap[n2][i] = out_attr[i][j];
+    }
+  }
+
+  for (i = 0; i < n; i++) {
+    uint32_t k = revmap[i].size();
+    e_in_count += k;
+
+    if (k > max_deg_in) max_deg_in = k;
+
+    in[i].resize(k);
+    in_attr[i].resize(k);
+
+    for (j = 0, rvit = revmap[i].begin(); j < k; j++, rvit++) {
+      in[i][j] = rvit->first;
+      Edge edge_attr = rvit->second;
+      in_attr[i][j] = edge_attr;
+      if (!e_attributemap.count(edge_attr)) {
+        e_attributemap[edge_attr] = true;
+        e_attr_count++;
+      }
+    }
+  }
+
+  for (i = 0; i < n; i++) {
+    uint32_t count = in[i].size() + out[i].size();
+    e_count += count;
+    if (count > max_degree) {
+      max_degree = count;
+    }
+  }
+}
+
+}  // namespace vflib
 #endif
 /* defined ARGRAPH_H */
-
-

--- a/include/Options.hpp
+++ b/include/Options.hpp
@@ -5,179 +5,169 @@
 #include <unistd.h>
 #endif
 
-#include <cinttypes>
 #include <stdio.h>
+
+#include <cinttypes>
 #include <iostream>
+
 #include "VFLib.h"
 
-#define VF3PGSS	 (1)
-#define VF3PWLS  (2)
+#define VF3PGSS (1)
+#define VF3PWLS (2)
 
-struct OptionStructure
-{
-	char *pattern;
-	char *target;
-	bool undirected;
-	bool storeSolutions;
+struct OptionStructure {
+  char *pattern;
+  char *target;
+  bool undirected;
+  bool storeSolutions;
 #ifdef VF3P
-	int8_t algo;
-	int16_t cpu;
-	int16_t numOfThreads;
-	bool lockFree;
-	int16_t ssrHighLimit;
-	int16_t ssrLocalStackLimit;
+  int8_t algo;
+  int16_t cpu;
+  int16_t numOfThreads;
+  bool lockFree;
+  int16_t ssrHighLimit;
+  int16_t ssrLocalStackLimit;
 #endif
-	bool verbose;
-	std::string format;
-	float repetitionTimeLimit;
+  bool verbose;
+  std::string format;
+  float repetitionTimeLimit;
 
-	OptionStructure():
-		pattern(nullptr),
-		target(nullptr),
-		undirected(false),
-		storeSolutions(false),
+  OptionStructure()
+      : pattern(nullptr),
+        target(nullptr),
+        undirected(false),
+        storeSolutions(false),
 #ifdef VF3P
-		algo(1),
-		cpu(-1),
-		numOfThreads(1),
-		lockFree(0),
-		ssrHighLimit(3),
-		ssrLocalStackLimit(10),
+        algo(1),
+        cpu(-1),
+        numOfThreads(1),
+        lockFree(0),
+        ssrHighLimit(3),
+        ssrLocalStackLimit(10),
 #endif
-		verbose(0),
-		format("vf"),
-		repetitionTimeLimit(1){}
+        verbose(0),
+        format("vf"),
+        repetitionTimeLimit(1) {
+  }
 };
 
 typedef OptionStructure Options;
 
-
-void PrintUsage()
-{
-	std::string outstring = "vf3 [pattern] [target] ";
+void PrintUsage() {
+  std::string outstring = "vf3 [pattern] [target] ";
 #ifdef VF3P
-  outstring += "-c [start cpu] -t [# of threads] -a [version id] -h [SSR high limit] -l [local stack limit] -k ";
+  outstring +=
+      "-c [start cpu] -t [# of threads] -a [version id] -h [SSR high limit] -l "
+      "[local stack limit] -k ";
 #endif
-	outstring += "-u -s -f [graph format]";
-	std::cout<<outstring<<std::endl;
+  outstring += "-u -s -f [graph format]";
+  std::cout << outstring << std::endl;
 }
 
-
-bool GetOptions(Options &opt, int argc, char **argv)
-{
-	/*
-	* -c Start CPU for the pool allocation
-	* -t Number of threads. Default [1]
-	* -a Version of the matcher to use. Default -1 is VF3
-	* -h SSR limit for the global stack. Default 3
-	* -l Local Stack limit. Default is pattern size
-	* -u Load graphs as undirected
-	* -k LockFree Version
-	* -r Minimum time in second for benchmark repetitions. Default 1.
-	* -s Print Solutions
-	* -f Graph format [vf, edge]
-	* -v Verbose: show all time
-	*/
+bool GetOptions(Options &opt, int argc, char **argv) {
+  /*
+   * -c Start CPU for the pool allocation
+   * -t Number of threads. Default [1]
+   * -a Version of the matcher to use. Default -1 is VF3
+   * -h SSR limit for the global stack. Default 3
+   * -l Local Stack limit. Default is pattern size
+   * -u Load graphs as undirected
+   * -k LockFree Version
+   * -r Minimum time in second for benchmark repetitions. Default 1.
+   * -s Print Solutions
+   * -f Graph format [vf, edge]
+   * -v Verbose: show all time
+   */
 #ifdef VF3P
-	std::string optionstring = ":a:c:t:r:f:h:l:sukv";
+  std::string optionstring = ":a:c:t:r:f:h:l:sukv";
 #else
   std::string optionstring = ":r:f:suv";
 #endif
 
-	char option;
-	while ((option = getopt (argc, argv, optionstring.c_str())) != -1)
-	{
-		switch (option)
-		{
+  char option;
+  while ((option = getopt(argc, argv, optionstring.c_str())) != -1) {
+    switch (option) {
 #ifdef VF3P
-			case 'a':
-				opt.algo = atoi(optarg);
-				break;
-			case 'c':
-				opt.cpu = atoi(optarg);
-				break;
-			case 'k':
-				opt.lockFree=1;
-				break;
-			case 't':
-				opt.numOfThreads = atoi(optarg);
-				break;
-			case 'h':
-				opt.ssrHighLimit = atoi(optarg);
-				break;
-			case 'l':
-				opt.ssrLocalStackLimit = atoi(optarg);
-				break;
+      case 'a':
+        opt.algo = atoi(optarg);
+        break;
+      case 'c':
+        opt.cpu = atoi(optarg);
+        break;
+      case 'k':
+        opt.lockFree = 1;
+        break;
+      case 't':
+        opt.numOfThreads = atoi(optarg);
+        break;
+      case 'h':
+        opt.ssrHighLimit = atoi(optarg);
+        break;
+      case 'l':
+        opt.ssrLocalStackLimit = atoi(optarg);
+        break;
 #endif
       case 's':
-				opt.storeSolutions = true;
-				break;
-			case 'r':
-				opt.repetitionTimeLimit = atof(optarg);
+        opt.storeSolutions = true;
         break;
-      		case 'u':
-				opt.undirected = true;
-				break;
-			case 'v':
-				opt.verbose = true;
-				break;
-			case 'f':
-				opt.format = std::string(optarg);
-				break;
-			case '?':
-				PrintUsage();
-				return false;
-		}
-
-	}
-	//additional parameter
-	if(argc < 2)
-	{
-		PrintUsage();
-		return false;
-	}
-
-	opt.pattern = argv[optind];
-	opt.target = argv[optind+1];
-	return true;
-}
-
-template<typename Node, typename Edge>
-vflib::ARGLoader<Node, Edge>* CreateLoader(const Options& opt, std::istream &in)
-{
-
-	if(opt.format == "vf")
-  {
-		return new vflib::FastStreamARGLoader<Node, Edge>(in, opt.undirected);
+      case 'r':
+        opt.repetitionTimeLimit = atof(optarg);
+        break;
+      case 'u':
+        opt.undirected = true;
+        break;
+      case 'v':
+        opt.verbose = true;
+        break;
+      case 'f':
+        opt.format = std::string(optarg);
+        break;
+      case '?':
+        PrintUsage();
+        return false;
+    }
   }
-	else if(opt.format == "edge")
-  {
-		return new vflib::EdgeStreamARGLoader<Node, Edge>(in, opt.undirected);
-	}
-	else
-	{
-		return nullptr;
-	}
+  // additional parameter
+  if (argc < 2) {
+    PrintUsage();
+    return false;
+  }
+
+  opt.pattern = argv[optind];
+  opt.target = argv[optind + 1];
+  return true;
 }
 
-vflib::MatchingEngine<state_t>* CreateMatchingEngine(const Options& opt)
-{
+template <typename Node, typename Edge>
+vflib::ARGLoader<Node, Edge> *CreateLoader(const Options &opt,
+                                           std::istream &in) {
+  if (opt.format == "vf") {
+    return new vflib::FastStreamARGLoader<Node, Edge>(in, opt.undirected);
+  } else if (opt.format == "edge") {
+    return new vflib::EdgeStreamARGLoader<Node, Edge>(in, opt.undirected);
+  } else {
+    return nullptr;
+  }
+}
+
+vflib::MatchingEngine<state_t> *CreateMatchingEngine(const Options &opt) {
 #ifdef VF3P
-	switch(opt.algo)
-	{
-		case VF3PGSS:
-			return new vflib::ParallelMatchingEngine<state_t >(opt.numOfThreads, opt.storeSolutions, opt.lockFree, opt.cpu);
-		case VF3PWLS:
-			return new vflib::ParallelMatchingEngineWLS<state_t >(opt.numOfThreads, opt.storeSolutions, opt.lockFree,
-                opt.cpu, opt.ssrHighLimit, opt.ssrLocalStackLimit);
-		default:
-			std::cout<<"Wrong Algorithm Selected\n";
-			std::cout<<"1: VF3P with GSS Only\n";
-			std::cout<<"2: VF3P with Local Stack and limited depth\n";
-			return nullptr;
-	}
+  switch (opt.algo) {
+    case VF3PGSS:
+      return new vflib::ParallelMatchingEngine<state_t>(
+          opt.numOfThreads, opt.storeSolutions, opt.lockFree, opt.cpu);
+    case VF3PWLS:
+      return new vflib::ParallelMatchingEngineWLS<state_t>(
+          opt.numOfThreads, opt.storeSolutions, opt.lockFree, opt.cpu,
+          opt.ssrHighLimit, opt.ssrLocalStackLimit);
+    default:
+      std::cout << "Wrong Algorithm Selected\n";
+      std::cout << "1: VF3P with GSS Only\n";
+      std::cout << "2: VF3P with Local Stack and limited depth\n";
+      return nullptr;
+  }
 #elif defined(VF3) || defined(VF3L)
-    return new vflib::MatchingEngine<state_t >(opt.storeSolutions);
+  return new vflib::MatchingEngine<state_t>(opt.storeSolutions);
 #endif
 }
 

--- a/include/Options.hpp
+++ b/include/Options.hpp
@@ -141,7 +141,7 @@ bool GetOptions(Options &opt, int argc, char **argv) {
 template <typename Node, typename Edge>
 vflib::ARGLoader<Node, Edge> *CreateLoader(const Options &opt,
                                            std::istream &in) {
-  if (opt.format == "vf") {
+  if (opt.format == "vf" || opt.format == "vfe") {
     return new vflib::FastStreamARGLoader<Node, Edge>(in, opt.undirected);
   } else if (opt.format == "edge") {
     return new vflib::EdgeStreamARGLoader<Node, Edge>(in, opt.undirected);
@@ -150,14 +150,15 @@ vflib::ARGLoader<Node, Edge> *CreateLoader(const Options &opt,
   }
 }
 
-vflib::MatchingEngine<state_t> *CreateMatchingEngine(const Options &opt) {
+template <typename StateType>
+vflib::MatchingEngine<StateType> *CreateMatchingEngine(const Options &opt) {
 #ifdef VF3P
   switch (opt.algo) {
     case VF3PGSS:
-      return new vflib::ParallelMatchingEngine<state_t>(
+      return new vflib::ParallelMatchingEngine<StateType>(
           opt.numOfThreads, opt.storeSolutions, opt.lockFree, opt.cpu);
     case VF3PWLS:
-      return new vflib::ParallelMatchingEngineWLS<state_t>(
+      return new vflib::ParallelMatchingEngineWLS<StateType>(
           opt.numOfThreads, opt.storeSolutions, opt.lockFree, opt.cpu,
           opt.ssrHighLimit, opt.ssrLocalStackLimit);
     default:
@@ -167,7 +168,7 @@ vflib::MatchingEngine<state_t> *CreateMatchingEngine(const Options &opt) {
       return nullptr;
   }
 #elif defined(VF3) || defined(VF3L)
-  return new vflib::MatchingEngine<state_t>(opt.storeSolutions);
+  return new vflib::MatchingEngine<StateType>(opt.storeSolutions);
 #endif
 }
 

--- a/include/VFLib.h
+++ b/include/VFLib.h
@@ -22,17 +22,24 @@ typedef std::string data_t;
 
 #ifdef VF3
 #include "VF3SubState.hpp"
-typedef vflib::VF3SubState<data_t, data_t, vflib::Empty, vflib::Empty> state_t;
+
+typedef vflib::VF3SubState<data_t, data_t, vflib::Empty, vflib::Empty>
+    noedgelabel_state_t;
+typedef vflib::VF3SubState<data_t, data_t, data_t, data_t> state_t;
 #elif defined(VF3L)
 #include "VF3LightSubState.hpp"
 typedef vflib::VF3LightSubState<data_t, data_t, vflib::Empty, vflib::Empty>
-    state_t;
+    noedgelabel_state_t;
+typedef vflib::VF3LightSubState<data_t, data_t, data_t, data_t> state_t;
 #elif defined(VF3P)
 #include "parallel/CloneableVF3ParallelSubState.hpp"
 #include "parallel/ParallelMatchingEngine.hpp"
 #include "parallel/ParallelMatchingEngineWLS.hpp"
+
 typedef vflib::CloneableVF3ParallelSubState<data_t, data_t, vflib::Empty,
                                             vflib::Empty>
+    noedgelabel_state_t;
+typedef vflib::CloneableVF3ParallelSubState<data_t, data_t, data_t, data_t>
     state_t;
 #endif
 

--- a/include/VFLib.h
+++ b/include/VFLib.h
@@ -1,19 +1,18 @@
 #ifndef VFLIB_H
 #define VFLIB_H
 
-#include "loaders/ARGLoader.hpp"
-#include "loaders/FastStreamARGLoader.hpp"
-#include "loaders/EdgeStreamARGLoader.hpp"
 #include "ARGraph.hpp"
-#include "NodeSorter.hpp"
-#include "VF3NodeSorter.hpp"
-#include "RINodeSorter.hpp"
 #include "FastCheck.hpp"
-#include "State.hpp"
-#include "ProbabilityStrategy.hpp"
-#include "NodeClassifier.hpp"
 #include "MatchingEngine.hpp"
-
+#include "NodeClassifier.hpp"
+#include "NodeSorter.hpp"
+#include "ProbabilityStrategy.hpp"
+#include "RINodeSorter.hpp"
+#include "State.hpp"
+#include "VF3NodeSorter.hpp"
+#include "loaders/ARGLoader.hpp"
+#include "loaders/EdgeStreamARGLoader.hpp"
+#include "loaders/FastStreamARGLoader.hpp"
 
 #ifndef VF3BIO
 typedef int32_t data_t;
@@ -26,12 +25,15 @@ typedef std::string data_t;
 typedef vflib::VF3SubState<data_t, data_t, vflib::Empty, vflib::Empty> state_t;
 #elif defined(VF3L)
 #include "VF3LightSubState.hpp"
-typedef vflib::VF3LightSubState<data_t, data_t, vflib::Empty, vflib::Empty> state_t;
+typedef vflib::VF3LightSubState<data_t, data_t, vflib::Empty, vflib::Empty>
+    state_t;
 #elif defined(VF3P)
+#include "parallel/CloneableVF3ParallelSubState.hpp"
 #include "parallel/ParallelMatchingEngine.hpp"
 #include "parallel/ParallelMatchingEngineWLS.hpp"
-#include "parallel/CloneableVF3ParallelSubState.hpp"
-typedef vflib::CloneableVF3ParallelSubState<data_t, data_t, vflib::Empty, vflib::Empty> state_t;
+typedef vflib::CloneableVF3ParallelSubState<data_t, data_t, vflib::Empty,
+                                            vflib::Empty>
+    state_t;
 #endif
 
 #endif /* VFLIB_H*/

--- a/include/loaders/EdgeStreamARGLoader.hpp
+++ b/include/loaders/EdgeStreamARGLoader.hpp
@@ -12,162 +12,142 @@
 #ifndef EDGESTREAMARGLOADER_HPP
 #define EDGESTREAMARGLOADER_HPP
 
-#include <iostream>
-#include <vector>
-#include <map>
-
 #include <Error.hpp>
+#include <iostream>
+#include <map>
+#include <vector>
 
 #include "ARGraph.hpp"
 
 namespace vflib {
 
 template <typename Node, typename Edge>
-class EdgeStreamARGLoader: public ARGLoader<Node, Edge> {
-    public:
-        /**
-         * @brief Reads the graph data from a text istream
-         * @param in The input stream
-         * @param undirected If true, the graph is undirected
-         * @param remove_isolated_nodes If true, the nodes that
-         *        have no edges are removed from the graph
-         */
-        EdgeStreamARGLoader(std::istream &in, bool undirected=false,
-                       bool remove_isolated_nodes=true);
-        virtual uint32_t NodeCount() const;
-        virtual Node GetNodeAttr(nodeID_t node);
-        virtual uint32_t OutEdgeCount(nodeID_t node) const;
-        virtual nodeID_t GetOutEdge(nodeID_t node, uint32_t i, Edge *pattr);
-        void SetNodeAttribute(Node attr) { node_attribute=attr; }
-        void SetEdgeAttribute(Edge attr) { edge_attribute=attr; }
+class EdgeStreamARGLoader : public ARGLoader<Node, Edge> {
+ public:
+  /**
+   * @brief Reads the graph data from a text istream
+   * @param in The input stream
+   * @param undirected If true, the graph is undirected
+   * @param remove_isolated_nodes If true, the nodes that
+   *        have no edges are removed from the graph
+   */
+  EdgeStreamARGLoader(std::istream &in, bool undirected = false,
+                      bool remove_isolated_nodes = true);
+  virtual uint32_t NodeCount() const;
+  virtual Node GetNodeAttr(nodeID_t node);
+  virtual uint32_t OutEdgeCount(nodeID_t node) const;
+  virtual nodeID_t GetOutEdge(nodeID_t node, uint32_t i, Edge *pattr);
+  void SetNodeAttribute(Node attr) { node_attribute = attr; }
+  void SetEdgeAttribute(Edge attr) { edge_attribute = attr; }
 
-    private:
-        Node node_attribute;
-        Edge edge_attribute;
-        uint32_t node_count;
-        std::vector<nodeID_t> forward, backward;
-        std::vector< std::map<nodeID_t, Empty> > edges;
-        typename std::map<nodeID_t, Empty>::iterator edge_iterator;
-        nodeID_t last_edge_node;
-        uint32_t last_edge_index;
-        void skipHeading(std::istream &in);
+ private:
+  Node node_attribute;
+  Edge edge_attribute;
+  uint32_t node_count;
+  std::vector<nodeID_t> forward, backward;
+  std::vector<std::map<nodeID_t, Empty> > edges;
+  typename std::map<nodeID_t, Empty>::iterator edge_iterator;
+  nodeID_t last_edge_node;
+  uint32_t last_edge_index;
+  void skipHeading(std::istream &in);
 };
 
-
-
 template <typename Node, typename Edge>
-EdgeStreamARGLoader<Node,Edge>
-::EdgeStreamARGLoader(std::istream &in, bool undirected,
-                      bool remove_isolated_nodes) {
-    last_edge_node = NULL_NODE;
-    uint32_t count=0;
+EdgeStreamARGLoader<Node, Edge>::EdgeStreamARGLoader(
+    std::istream &in, bool undirected, bool remove_isolated_nodes) {
+  last_edge_node = NULL_NODE;
+  uint32_t count = 0;
 
-    if (!in.good())
-      error("End of file or reading error");
+  if (!in.good()) error("End of file or reading error");
 
-    skipHeading(in);
-    nodeID_t n1, n2;
-    while (true) {
-        in >> n1 >> n2;
-        n1--;
-        n2--;
-        if (!in.good())
-            break;
-        if (n1 == n2)
-            error("File format error. Self edges are not allowed!", n1, n2);
-        if (n1>=count)
-            count = n1+1;
-        if (n2>=count)
-            count = n2+1;
-        edges.resize(count);
-        forward.resize(count, 0);
-        forward[n1]=1;
-        forward[n2]=1;
-        edges[n1][n2] = edge_attribute;
-        if (undirected)
-            edges[n2][n1] = edge_attribute;
+  skipHeading(in);
+  nodeID_t n1, n2;
+  while (true) {
+    in >> n1 >> n2;
+    n1--;
+    n2--;
+    if (!in.good()) break;
+    if (n1 == n2)
+      error("File format error. Self edges are not allowed!", n1, n2);
+    if (n1 >= count) count = n1 + 1;
+    if (n2 >= count) count = n2 + 1;
+    edges.resize(count);
+    forward.resize(count, 0);
+    forward[n1] = 1;
+    forward[n2] = 1;
+    edges[n1][n2] = edge_attribute;
+    if (undirected) edges[n2][n1] = edge_attribute;
+  }
+
+  if (remove_isolated_nodes) {
+    backward.reserve(count);
+    node_count = 0;
+    for (uint32_t i = 0; i < count; i++) {
+      if (forward[i] > 0) {
+        forward[i] = node_count++;
+        backward.push_back(i);
+      }
     }
-
-    if (remove_isolated_nodes) {
-        backward.reserve(count);
-        node_count=0;
-        for(uint32_t i=0; i<count; i++) {
-            if (forward[i]>0) {
-                forward[i]=node_count ++;
-                backward.push_back(i);
-            }
-        }
-    } else {
-        node_count=count;
-        backward.resize(count);
-        for(uint32_t i=0; i<count; i++) {
-            forward[i]=i;
-            backward[i]=i;
-        }
+  } else {
+    node_count = count;
+    backward.resize(count);
+    for (uint32_t i = 0; i < count; i++) {
+      forward[i] = i;
+      backward[i] = i;
     }
+  }
 }
 
 template <typename Node, typename Edge>
-uint32_t
-EdgeStreamARGLoader<Node,Edge>
-::NodeCount() const {
-    return node_count;
+uint32_t EdgeStreamARGLoader<Node, Edge>::NodeCount() const {
+  return node_count;
 }
 
 template <typename Node, typename Edge>
-Node
-EdgeStreamARGLoader<Node,Edge>
-::GetNodeAttr(nodeID_t node) {
-    return node_attribute;
+Node EdgeStreamARGLoader<Node, Edge>::GetNodeAttr(nodeID_t node) {
+  return node_attribute;
 }
 
 template <typename Node, typename Edge>
-uint32_t
-EdgeStreamARGLoader<Node,Edge>
-::OutEdgeCount(nodeID_t node) const {
-    return edges[backward[node]].size();
+uint32_t EdgeStreamARGLoader<Node, Edge>::OutEdgeCount(nodeID_t node) const {
+  return edges[backward[node]].size();
 }
 
 template <typename Node, typename Edge>
-nodeID_t
-EdgeStreamARGLoader<Node,Edge>
-::GetOutEdge(nodeID_t node, uint32_t i, Edge *pattr) {
-    assert (i<OutEdgeCount(node));
+nodeID_t EdgeStreamARGLoader<Node, Edge>::GetOutEdge(nodeID_t node, uint32_t i,
+                                                     Edge *pattr) {
+  assert(i < OutEdgeCount(node));
 
-    if (node != last_edge_node) {
-        last_edge_node = node;
-        edge_iterator = edges[backward[node]].begin();
-        last_edge_index = 0;
-    }
-    while (last_edge_index < i) {
-        edge_iterator ++;
-        last_edge_index ++;
-    }
+  if (node != last_edge_node) {
+    last_edge_node = node;
+    edge_iterator = edges[backward[node]].begin();
+    last_edge_index = 0;
+  }
+  while (last_edge_index < i) {
+    edge_iterator++;
+    last_edge_index++;
+  }
 
-    while (last_edge_index > i) {
-        edge_iterator --;
-        last_edge_index --;
-    }
+  while (last_edge_index > i) {
+    edge_iterator--;
+    last_edge_index--;
+  }
 
-    *pattr = edge_attribute;
-    return forward[edge_iterator->first];
+  *pattr = edge_attribute;
+  return forward[edge_iterator->first];
 }
-
 
 template <typename Node, typename Edge>
-void
-EdgeStreamARGLoader<Node,Edge>
-::skipHeading(std::istream & in) {
-    const int maxline=256*1024;
-    int c=in.peek();
-    while (c!=EOF && (isspace(c) || c=='#')) {
-        in.get();
-        if (c=='#')
-            in.ignore(maxline, '\n');
-        c=in.peek();
-    }
+void EdgeStreamARGLoader<Node, Edge>::skipHeading(std::istream &in) {
+  const int maxline = 256 * 1024;
+  int c = in.peek();
+  while (c != EOF && (isspace(c) || c == '#')) {
+    in.get();
+    if (c == '#') in.ignore(maxline, '\n');
+    c = in.peek();
+  }
 }
 
-} // End namespace vflib
+}  // End namespace vflib
 
 #endif

--- a/include/loaders/EdgeStreamARGLoader.hpp
+++ b/include/loaders/EdgeStreamARGLoader.hpp
@@ -45,8 +45,8 @@ class EdgeStreamARGLoader : public ARGLoader<Node, Edge> {
   Edge edge_attribute;
   uint32_t node_count;
   std::vector<nodeID_t> forward, backward;
-  std::vector<std::map<nodeID_t, Empty> > edges;
-  typename std::map<nodeID_t, Empty>::iterator edge_iterator;
+  std::vector<std::map<nodeID_t, Edge> > edges;
+  typename std::map<nodeID_t, Edge>::iterator edge_iterator;
   nodeID_t last_edge_node;
   uint32_t last_edge_index;
   void skipHeading(std::istream &in);

--- a/include/loaders/FastStreamARGLoader.hpp
+++ b/include/loaders/FastStreamARGLoader.hpp
@@ -9,121 +9,106 @@
 #ifndef FASTSTREAMARGLOADER_HPP
 #define FASTSTREAMARGLOADER_HPP
 
-#include <iostream>
-#include <vector>
-#include <map>
-
 #include <Error.hpp>
+#include <iostream>
+#include <map>
+#include <vector>
 
 #include "ARGraph.hpp"
 
 namespace vflib {
 
 template <typename Node, typename Edge>
-class FastStreamARGLoader: public ARGLoader<Node, Edge> {
-    public:
-        /**
-         * @brief Reads the graph data from a text istream
-         * @param in The input stream
-         * @param undirected If true, the graph is undirected
-         */
-        FastStreamARGLoader(std::istream &in, bool undirected=false);
-        virtual uint32_t NodeCount() const;
-        virtual Node GetNodeAttr(nodeID_t node);
-        virtual uint32_t OutEdgeCount(nodeID_t node) const;
-        virtual nodeID_t GetOutEdge(nodeID_t node, uint32_t i, Edge *pattr);
+class FastStreamARGLoader : public ARGLoader<Node, Edge> {
+ public:
+  /**
+   * @brief Reads the graph data from a text istream
+   * @param in The input stream
+   * @param undirected If true, the graph is undirected
+   */
+  FastStreamARGLoader(std::istream &in, bool undirected = false);
+  virtual uint32_t NodeCount() const;
+  virtual Node GetNodeAttr(nodeID_t node);
+  virtual uint32_t OutEdgeCount(nodeID_t node) const;
+  virtual nodeID_t GetOutEdge(nodeID_t node, uint32_t i, Edge *pattr);
 
-    private:
-        uint32_t node_count;
-        std::vector<Node> nodes;
-        std::vector< std::map<nodeID_t, Edge> > edges;
-        typename std::map<nodeID_t, Edge>::iterator edge_iterator;
-        nodeID_t last_edge_node;
-        uint32_t last_edge_index;
+ private:
+  uint32_t node_count;
+  std::vector<Node> nodes;
+  std::vector<std::map<nodeID_t, Edge> > edges;
+  typename std::map<nodeID_t, Edge>::iterator edge_iterator;
+  nodeID_t last_edge_node;
+  uint32_t last_edge_index;
 };
 
-
-
 template <typename Node, typename Edge>
-FastStreamARGLoader<Node,Edge>
-::FastStreamARGLoader(std::istream &in, bool undirected) {
-    last_edge_node = NULL_NODE;
+FastStreamARGLoader<Node, Edge>::FastStreamARGLoader(std::istream &in,
+                                                     bool undirected) {
+  last_edge_node = NULL_NODE;
 
-    if (!in.good())
-      error("End of file or reading error");
+  if (!in.good()) error("End of file or reading error");
 
-    in >> node_count;
-    nodes.resize(node_count);
-    edges.resize(node_count);
-    uint32_t edge_count;
-    nodeID_t i, j, n1, n2;
-    for(i=0; i<node_count; i++) {
-        in >> n1 >> nodes[i];
-        if (n1 != i)
-            error("Error in file format reading node", n1);
+  in >> node_count;
+  nodes.resize(node_count);
+  edges.resize(node_count);
+  uint32_t edge_count;
+  nodeID_t i, j, n1, n2;
+  for (i = 0; i < node_count; i++) {
+    in >> n1 >> nodes[i];
+    if (n1 != i) error("Error in file format reading node", n1);
+  }
+
+  for (i = 0; i < node_count; i++) {
+    in >> edge_count;
+    for (j = 0; j < edge_count; j++) {
+      in >> n1 >> n2;
+      if (n1 != i || n2 >= node_count || n1 == n2)
+        error("Error in file format reading edge", n1, n2);
+      in >> edges[n1][n2];
+      if (undirected) edges[n2][n1] = edges[n1][n2];
     }
-
-    for(i=0; i<node_count; i++) {
-        in >> edge_count;
-        for(j=0; j<edge_count; j++) {
-            in >> n1 >> n2;
-            if (n1 != i || n2 >= node_count || n1==n2)
-                error("Error in file format reading edge", n1, n2);
-            in >> edges[n1][n2];
-            if (undirected)
-                edges[n2][n1] = edges[n1][n2];
-        }
-    }
+  }
 }
 
 template <typename Node, typename Edge>
-uint32_t
-FastStreamARGLoader<Node,Edge>
-::NodeCount() const {
-    return node_count;
+uint32_t FastStreamARGLoader<Node, Edge>::NodeCount() const {
+  return node_count;
 }
 
 template <typename Node, typename Edge>
-Node
-FastStreamARGLoader<Node,Edge>
-::GetNodeAttr(nodeID_t node) {
-    return nodes[node];
+Node FastStreamARGLoader<Node, Edge>::GetNodeAttr(nodeID_t node) {
+  return nodes[node];
 }
 
 template <typename Node, typename Edge>
-uint32_t
-FastStreamARGLoader<Node,Edge>
-::OutEdgeCount(nodeID_t node) const {
-    return edges[node].size();
+uint32_t FastStreamARGLoader<Node, Edge>::OutEdgeCount(nodeID_t node) const {
+  return edges[node].size();
 }
 
 template <typename Node, typename Edge>
-nodeID_t
-FastStreamARGLoader<Node,Edge>
-::GetOutEdge(nodeID_t node, uint32_t i, Edge *pattr) {
-    assert (i<OutEdgeCount(node));
+nodeID_t FastStreamARGLoader<Node, Edge>::GetOutEdge(nodeID_t node, uint32_t i,
+                                                     Edge *pattr) {
+  assert(i < OutEdgeCount(node));
 
-    if (node != last_edge_node) {
-        last_edge_node = node;
-        edge_iterator = edges[node].begin();
-        last_edge_index = 0;
-    }
-    while (last_edge_index < i) {
-        edge_iterator ++;
-        last_edge_index ++;
-    }
+  if (node != last_edge_node) {
+    last_edge_node = node;
+    edge_iterator = edges[node].begin();
+    last_edge_index = 0;
+  }
+  while (last_edge_index < i) {
+    edge_iterator++;
+    last_edge_index++;
+  }
 
-    while (last_edge_index > i) {
-        edge_iterator --;
-        last_edge_index --;
-    }
+  while (last_edge_index > i) {
+    edge_iterator--;
+    last_edge_index--;
+  }
 
-    *pattr = edge_iterator->second;
-    return edge_iterator->first;
+  *pattr = edge_iterator->second;
+  return edge_iterator->first;
 }
 
-
-
-} // End namespace vflib
+}  // End namespace vflib
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -1,233 +1,227 @@
 #include <stdio.h>
-#include <iostream>
-#include <fstream>
 #include <stdlib.h>
-#include <string>
 #include <time.h>
+
 #include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <string>
 #ifndef WIN32
-#include <csignal>
-#include <unistd.h>
-#include <sys/time.h>
-#include <sys/stat.h>
 #include <errno.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <csignal>
 #else
 #include <Windows.h>
 #include <stdint.h>
 #endif
 
-#include "WindowsTime.h"
-#include "VFLib.h"
 #include "Options.hpp"
+#include "VFLib.h"
+#include "WindowsTime.h"
 
 using namespace vflib;
 
 #ifndef WIN32
 void sig_handler(int sig) {
-    switch (sig) {
-		case SIGKILL:
-			std::cout << "Killed \n";
-			exit(-1);
-		case SIGABRT:
-			std::cout << "Aborted \n";
-			exit(-1);
-		case SIGTERM:
-			std::cout << "Terminated \n";
-			exit(-1);
-		case SIGSEGV:
-			std::cout << "Segmentation fault \n";
-			exit(-1);
-		case SIGSTOP:
-			std::cout << "Stopped \n";
-			exit(-1);
-		case SIGCHLD:
-			std::cout << "Child stopped or terminated \n";
-			exit(-1);
-		default:
-			std::cout << "Unexpected signal " <<  sig <<"\n";
-			exit(-1);
-		}
+  switch (sig) {
+    case SIGKILL:
+      std::cout << "Killed \n";
+      exit(-1);
+    case SIGABRT:
+      std::cout << "Aborted \n";
+      exit(-1);
+    case SIGTERM:
+      std::cout << "Terminated \n";
+      exit(-1);
+    case SIGSEGV:
+      std::cout << "Segmentation fault \n";
+      exit(-1);
+    case SIGSTOP:
+      std::cout << "Stopped \n";
+      exit(-1);
+    case SIGCHLD:
+      std::cout << "Child stopped or terminated \n";
+      exit(-1);
+    default:
+      std::cout << "Unexpected signal " << sig << "\n";
+      exit(-1);
+  }
 }
 #endif
 
 #ifdef TRACE
 std::string& remove_chars(std::string& s, const std::string& chars) {
-    s.erase(remove_if(s.begin(), s.end(), [&chars](const char& c) {
-        return chars.find(c) != std::string::npos;
-    }), s.end());
-    return s;
+  s.erase(remove_if(s.begin(), s.end(),
+                    [&chars](const char& c) {
+                      return chars.find(c) != std::string::npos;
+                    }),
+          s.end());
+  return s;
 }
 #endif
 
 static long long state_counter = 0;
 
-int32_t main(int32_t argc, char** argv)
-{
-	Options opt;
+int32_t main(int32_t argc, char** argv) {
+  Options opt;
 
-	uint32_t n1, n2;
-	double timeAll = 0;
-	double totalExecTime= 0;
-	double timeFirst = 0;
-	double timeLast  = 0;
-	double timeLoad = 0;
-	int rep = 0;
-	struct timeval start, loading, fastcheck, classification, iter, end;
-	std::vector<MatchingSolution> solutions;
-	std::vector<uint32_t> class_patt;
-	std::vector<uint32_t> class_targ;
-	uint32_t classes_count;
+  uint32_t n1, n2;
+  double timeAll = 0;
+  double totalExecTime = 0;
+  double timeFirst = 0;
+  double timeLast = 0;
+  double timeLoad = 0;
+  int rep = 0;
+  struct timeval start, loading, fastcheck, classification, iter, end;
+  std::vector<MatchingSolution> solutions;
+  std::vector<uint32_t> class_patt;
+  std::vector<uint32_t> class_targ;
+  uint32_t classes_count;
 
-	state_counter = 0;
-	size_t sols = 0;
+  state_counter = 0;
+  size_t sols = 0;
 
 #ifndef WIN32
-	std::signal(SIGKILL, sig_handler);
-	std::signal(SIGABRT, sig_handler);
-	std::signal(SIGTERM, sig_handler);
-	std::signal(SIGSEGV, sig_handler);
-	std::signal(SIGSTOP, sig_handler);
-	std::signal(SIGCHLD, sig_handler);
+  std::signal(SIGKILL, sig_handler);
+  std::signal(SIGABRT, sig_handler);
+  std::signal(SIGTERM, sig_handler);
+  std::signal(SIGSEGV, sig_handler);
+  std::signal(SIGSTOP, sig_handler);
+  std::signal(SIGCHLD, sig_handler);
 #endif
 
-	if(!GetOptions(opt, argc, argv))
-	{
-		exit(-1);
-	}
+  if (!GetOptions(opt, argc, argv)) {
+    exit(-1);
+  }
 
 #ifdef TRACE
-	int status;
-	std::string pattern_name(opt.pattern);
-	std::string target_name(opt.target);
+  int status;
+  std::string pattern_name(opt.pattern);
+  std::string target_name(opt.target);
 
-	pattern_name = pattern_name.substr(pattern_name.find_last_of("/\\") + 1);
-	target_name = target_name.substr(target_name.find_last_of("/\\") + 1);
+  pattern_name = pattern_name.substr(pattern_name.find_last_of("/\\") + 1);
+  target_name = target_name.substr(target_name.find_last_of("/\\") + 1);
 
-	pattern_name = remove_chars(pattern_name, "./");
-	target_name = remove_chars(target_name, "./");
+  pattern_name = remove_chars(pattern_name, "./");
+  target_name = remove_chars(target_name, "./");
 
-	std::string outpath(argv[3]);
+  std::string outpath(argv[3]);
 
-	//mkdir -p foo/bar/zoo/andsoforth
-	status = mkdir(outpath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-	//std::cout<<status<<" "<<errno<<std::endl;
-	std::string outfilename = outpath+"/"+pattern_name+target_name+".cvs";
-	//std::cout << outfilename;
+  // mkdir -p foo/bar/zoo/andsoforth
+  status = mkdir(outpath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+  // std::cout<<status<<" "<<errno<<std::endl;
+  std::string outfilename = outpath + "/" + pattern_name + target_name + ".cvs";
+  // std::cout << outfilename;
 #endif
 
-	gettimeofday(&start, NULL);
+  gettimeofday(&start, NULL);
 
-	std::ifstream graphInPat(opt.pattern);
-	std::ifstream graphInTarg(opt.target);
+  std::ifstream graphInPat(opt.pattern);
+  std::ifstream graphInTarg(opt.target);
 
-	ARGLoader<data_t, Empty>* pattloader = CreateLoader<data_t, Empty>(opt, graphInPat);
-	ARGLoader<data_t, Empty>* targloader = CreateLoader<data_t, Empty>(opt, graphInTarg);
+  ARGLoader<data_t, Empty>* pattloader =
+      CreateLoader<data_t, Empty>(opt, graphInPat);
+  ARGLoader<data_t, Empty>* targloader =
+      CreateLoader<data_t, Empty>(opt, graphInTarg);
 
-	ARGraph<data_t, Empty> patt_graph(pattloader);
-	ARGraph<data_t, Empty> targ_graph(targloader);
+  ARGraph<data_t, Empty> patt_graph(pattloader);
+  ARGraph<data_t, Empty> targ_graph(targloader);
 
-	if(opt.verbose)
-	{
-		gettimeofday(&loading, NULL);
-		timeLoad = GetElapsedTime(start, loading);
-		std::cout<<"Loaded in: "<<timeLoad<<std::endl;
-	}
+  if (opt.verbose) {
+    gettimeofday(&loading, NULL);
+    timeLoad = GetElapsedTime(start, loading);
+    std::cout << "Loaded in: " << timeLoad << std::endl;
+  }
 
-	n1 = patt_graph.NodeCount();
-	n2 = targ_graph.NodeCount();
+  n1 = patt_graph.NodeCount();
+  n2 = targ_graph.NodeCount();
 
-	MatchingEngine<state_t >* me = CreateMatchingEngine(opt);
+  MatchingEngine<state_t>* me = CreateMatchingEngine(opt);
 
-	if(!me)
-	{
-		exit(-1);
-	}
+  if (!me) {
+    exit(-1);
+  }
 
-	gettimeofday(&start, NULL);
-	FastCheck<data_t, data_t, Empty, Empty > check(&patt_graph, &targ_graph);
-	if(check.CheckSubgraphIsomorphism())
-	{
-		if(opt.verbose)
-		{
-			gettimeofday(&fastcheck, NULL);
-			timeLoad = GetElapsedTime(start, fastcheck);
-			std::cout<<"FastCheck in: "<<timeLoad<<std::endl;
-		}
+  gettimeofday(&start, NULL);
+  FastCheck<data_t, data_t, Empty, Empty> check(&patt_graph, &targ_graph);
+  if (check.CheckSubgraphIsomorphism()) {
+    if (opt.verbose) {
+      gettimeofday(&fastcheck, NULL);
+      timeLoad = GetElapsedTime(start, fastcheck);
+      std::cout << "FastCheck in: " << timeLoad << std::endl;
+    }
 
-		gettimeofday(&start, NULL);
-		NodeClassifier<data_t, Empty> classifier(&targ_graph);
-		NodeClassifier<data_t, Empty> classifier2(&patt_graph, classifier);
-		class_patt = classifier2.GetClasses();
-		class_targ = classifier.GetClasses();
-		classes_count = classifier.CountClasses();
+    gettimeofday(&start, NULL);
+    NodeClassifier<data_t, Empty> classifier(&targ_graph);
+    NodeClassifier<data_t, Empty> classifier2(&patt_graph, classifier);
+    class_patt = classifier2.GetClasses();
+    class_targ = classifier.GetClasses();
+    classes_count = classifier.CountClasses();
 
-		if(opt.verbose)
-		{
-			gettimeofday(&classification, NULL);
-			timeLoad = GetElapsedTime(start, classification);
-			std::cout<<"Classification in: "<<timeLoad<<std::endl;
-		}
-	}
+    if (opt.verbose) {
+      gettimeofday(&classification, NULL);
+      timeLoad = GetElapsedTime(start, classification);
+      std::cout << "Classification in: " << timeLoad << std::endl;
+    }
+  }
 
-	#ifndef TRACE
-	do
-	{
-		rep++;
-		me->ResetSolutionCounter();
+#ifndef TRACE
+  do {
+    rep++;
+    me->ResetSolutionCounter();
 
-		gettimeofday(&iter, NULL);
-	#endif
-		if(check.CheckSubgraphIsomorphism())
-		{
-			VF3NodeSorter<data_t, Empty, SubIsoNodeProbability<data_t, Empty> > sorter(&targ_graph);
-			std::vector<nodeID_t> sorted = sorter.SortNodes(&patt_graph);
+    gettimeofday(&iter, NULL);
+#endif
+    if (check.CheckSubgraphIsomorphism()) {
+      VF3NodeSorter<data_t, Empty, SubIsoNodeProbability<data_t, Empty> >
+          sorter(&targ_graph);
+      std::vector<nodeID_t> sorted = sorter.SortNodes(&patt_graph);
 
-			#ifdef TRACE
-			me->InitTrace(outfilename);
-			#endif
+#ifdef TRACE
+      me->InitTrace(outfilename);
+#endif
 
-			state_t s0(&patt_graph, &targ_graph, class_patt.data(), class_targ.data(), classes_count, sorted.data());
-			me->FindAllMatchings(s0);
-			#ifdef TRACE
-			me->FlushTrace();
-			#endif
+      state_t s0(&patt_graph, &targ_graph, class_patt.data(), class_targ.data(),
+                 classes_count, sorted.data());
+      me->FindAllMatchings(s0);
+#ifdef TRACE
+      me->FlushTrace();
+#endif
+    }
 
-		}
+#ifndef TRACE
+    gettimeofday(&end, NULL);
 
-	#ifndef TRACE
-		gettimeofday(&end,NULL);
+    totalExecTime += GetElapsedTime(iter, end);
+    end = me->GetFirstSolutionTime();
+    timeFirst += GetElapsedTime(iter, end);
+  } while (totalExecTime < opt.repetitionTimeLimit);
+  timeAll = totalExecTime / rep;
+  timeFirst /= rep;
 
-		totalExecTime += GetElapsedTime(iter, end);
-		end = me->GetFirstSolutionTime();
-		timeFirst += GetElapsedTime(iter, end);
-	} while (totalExecTime < opt.repetitionTimeLimit);
-	timeAll = totalExecTime/rep;
-	timeFirst /= rep;
+  if (opt.storeSolutions) {
+    me->GetSolutions(solutions);
+    std::cout << "Solution Found" << std::endl;
+    std::vector<MatchingSolution>::iterator it;
+    for (it = solutions.begin(); it != solutions.end(); it++) {
+      std::cout << me->SolutionToString(*it) << std::endl;
+    }
+  }
 
-	if(opt.storeSolutions)
-	{
-		me->GetSolutions(solutions);
-		std::cout << "Solution Found" << std::endl;
-		std::vector<MatchingSolution>::iterator it;
-		for(it = solutions.begin(); it != solutions.end(); it++)
-		{
-			std::cout<< me->SolutionToString(*it) << std::endl;
-		}
-	}
-
-	#endif
-	sols = me->GetSolutionsCount();
-	if(opt.verbose)
-	{
-		std::cout<<"First Solution in: "<<timeFirst<<std::endl;
-		std::cout<<"Matching Finished in: "<<timeAll<<std::endl;
-		std::cout<<"Solutions: "<<sols<<std::endl;
-	}else
-	{
-		std::cout << sols << " " << timeFirst << " " << timeAll <<std::endl;
-	}
-	delete me;
-  	delete pattloader;
-  	delete targloader;
-	return 0;
+#endif
+  sols = me->GetSolutionsCount();
+  if (opt.verbose) {
+    std::cout << "First Solution in: " << timeFirst << std::endl;
+    std::cout << "Matching Finished in: " << timeAll << std::endl;
+    std::cout << "Solutions: " << sols << std::endl;
+  } else {
+    std::cout << sols << " " << timeFirst << " " << timeAll << std::endl;
+  }
+  delete me;
+  delete pattloader;
+  delete targloader;
+  return 0;
 }


### PR DESCRIPTION
Fixes #4 

- Created fresh template instances for Integer label types
- Abstract out a `solve` template function to handle any data type for labels and states
- Added an option `vfe` to parse the input file in VF format with integer edge labels.
- Fix hardcoded datatypes in dataloaders.
- Add command for compiling as a shared library in Makefile

PS: For easy reviewing please start review after the commit `Reformat files`